### PR TITLE
Added `forget` to a `BluetoothDevice`

### DIFF
--- a/.github/workflows/run_ci.yml
+++ b/.github/workflows/run_ci.yml
@@ -2,13 +2,13 @@ name: Run CI
 on:
   push:
     paths:
-      - /lib/**
-      - /test/**
-      - /pubspec.yaml
-      - /.github/workflows/run_ci.yml
-      - /example/lib/**
-      - /example/test/**
-      - /example/pubspec.yaml
+      - lib/**
+      - test/**
+      - pubspec.yaml
+      - .github/workflows/run_ci.yml
+      - example/lib/**
+      - example/test/**
+      - example/pubspec.yaml
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * If you were using `defaultUuid.ordinal` then you should now use `defaultUuid.index`.
   * Some names may slightly differ.
 * **Breaking** Upgraded minimum dart sdk to `2.17`
+* Added `forget` to a `BluetoothDevice`, to forget a device.
 
 ## 0.1.0
 

--- a/example/lib/pages/device_services_page.dart
+++ b/example/lib/pages/device_services_page.dart
@@ -2,6 +2,7 @@ import "dart:math";
 
 import "package:flutter/material.dart";
 import "package:flutter_web_bluetooth/flutter_web_bluetooth.dart";
+import "package:flutter_web_bluetooth/js_web_bluetooth.dart";
 import "package:flutter_web_bluetooth_example/widgets/bluetooth_advertisements_widget.dart";
 import "package:flutter_web_bluetooth_example/widgets/bluetooth_services_widget.dart";
 
@@ -17,6 +18,14 @@ class DeviceServicesPage extends StatefulWidget {
 }
 
 class DeviceServicesState extends State<DeviceServicesPage> {
+  Color? _getErrorColor() {
+    if (!mounted) {
+      return null;
+    }
+    final theme = Theme.of(context);
+    return theme.colorScheme.error;
+  }
+
   @override
   Widget build(final BuildContext context) {
     const appbarHeight = 56.0;
@@ -27,6 +36,35 @@ class DeviceServicesState extends State<DeviceServicesPage> {
     return Scaffold(
         appBar: AppBar(
           title: SelectableText(widget.bluetoothDevice.name ?? "No name set"),
+          actions: [
+            ElevatedButton(
+                onPressed: () async {
+                  late String message;
+                  try {
+                    await widget.bluetoothDevice.forget();
+                    debugPrint(
+                        "Forgot device: ${widget.bluetoothDevice.name}, ${widget.bluetoothDevice.id}");
+                    message = "";
+                  } on NativeAPINotImplementedError {
+                    message = "Forget is not implemented in this browser";
+                  } catch (e, s) {
+                    debugPrint("$e\n$s");
+                    message = "Unknown error: $e";
+                  }
+
+                  if (mounted) {
+                    if (message.isNotEmpty) {
+                      ScaffoldMessenger.maybeOf(context)?.showSnackBar(SnackBar(
+                        content: Text(message),
+                        backgroundColor: _getErrorColor(),
+                      ));
+                    } else {
+                      Navigator.pop(context);
+                    }
+                  }
+                },
+                child: const Text("Forget"))
+          ],
         ),
         body: SingleChildScrollView(
             scrollDirection: Axis.vertical,

--- a/example/lib/widgets/service_widget.dart
+++ b/example/lib/widgets/service_widget.dart
@@ -30,8 +30,9 @@ class ServiceState extends State<ServiceWidget> {
   Future<_ServiceAndCharacteristic>? _serviceAndCharacteristics;
 
   @override
-  Future<void> initState() async {
+  void initState() {
     super.initState();
+    // ignore: discarded_futures
     _serviceAndCharacteristics = _getServicesAndCharacteristics();
   }
 

--- a/lib/src/bluetooth_device.dart
+++ b/lib/src/bluetooth_device.dart
@@ -90,6 +90,8 @@ class BluetoothDevice extends AdvertisementBluetoothDevice {
       _advertisementSubject;
   AbortController? _advertisementAbortController;
 
+  bool _forgotten = false;
+
   ///
   /// A stream which will emit all the advertisements received.
   ///
@@ -242,6 +244,41 @@ class BluetoothDevice extends AdvertisementBluetoothDevice {
 
     _connectionSubject?.add(true);
   }
+
+  ///
+  /// Forget the device. This means that the device will no longer show up
+  /// in [FlutterWebBluetooth.devices] stream.
+  ///
+  /// You can no longer communicate with the device after calling [forget].
+  /// It basically reverts into a [AdvertisementBluetoothDevice].
+  ///
+  /// Will throw [NativeAPINotImplementedError] if the browser/ user agent
+  /// doesn't have the method implemented.
+  ///
+  /// Will throw [StateError] if the device has already been forgotten.
+  ///
+  Future<void> forget() async {
+    if (_forgotten) {
+      // Stops you from crashing the browser by forgetting a device twice.
+      throw StateError("The device has already been forgotten");
+    }
+    await _bluetoothDevice.forget();
+    _forgotten = true;
+    // Remove the device from the list of devices.
+    await FlutterWebBluetooth.instance._forgetDevice(this);
+  }
+
+  ///
+  /// A bool representing if the device has already been forgotten.
+  ///
+  /// Will be `true` after calling [forget]. Otherwise it will be `false`.
+  ///
+  bool get isForgotten => _forgotten;
+
+  ///
+  /// Check to see if the browser/ user agent has [forget].
+  ///
+  bool get hasForget => _bluetoothDevice.hasForget;
 
   ///
   /// Check to see if the current browser supports the [watchAdvertisements]

--- a/lib/src/flutter_web_bluetooth_interface.dart
+++ b/lib/src/flutter_web_bluetooth_interface.dart
@@ -185,4 +185,12 @@ abstract class FlutterWebBluetoothInterface {
   /// [BluetoothDevice.advertisementsUseMemory].
   ///
   bool defaultAdvertisementsMemory = true;
+
+  ///
+  /// The [devices] stream has a [Set] of [BluetoothDevice]s. If the
+  /// [BluetoothDevice.forget] method is used then it should also be removed
+  /// from the [devices] stream. This method takes in a [BluetoothDevice] to
+  /// be removed from this stream.
+  ///
+  Future<void> _forgetDevice(final BluetoothDevice device);
 }

--- a/lib/src/flutter_web_bluetooth_unsupported.dart
+++ b/lib/src/flutter_web_bluetooth_unsupported.dart
@@ -96,4 +96,9 @@ class FlutterWebBluetooth extends FlutterWebBluetoothInterface {
   @override
   Stream<AdvertisementReceivedEvent<AdvertisementBluetoothDevice>>
       get advertisements => const Stream.empty();
+
+  @override
+  Future<void> _forgetDevice(final BluetoothDevice device) async {
+    // Do nothing
+  }
 }

--- a/lib/src/flutter_web_bluetooth_web.dart
+++ b/lib/src/flutter_web_bluetooth_web.dart
@@ -305,7 +305,8 @@ class FlutterWebBluetooth extends FlutterWebBluetoothInterface {
       final convertedOptions = options.toRequestOptions();
       return await Bluetooth.requestLEScan(convertedOptions);
     } on BrowserError catch (e) {
-      if (e.message.startsWith("InvalidStateError")) {
+      if (e.message.startsWith("InvalidStateError") ||
+          e.message.startsWith("NotFoundError")) {
         throw BluetoothAdapterNotAvailable("requestLEScan");
       }
       rethrow;
@@ -330,5 +331,19 @@ class FlutterWebBluetooth extends FlutterWebBluetoothInterface {
       get advertisements {
     _startAdvertisementStream();
     return _advertisementSubject!.stream;
+  }
+
+  ///
+  /// The [devices] stream has a [Set] of [BluetoothDevice]s. If the
+  /// [BluetoothDevice.forget] method is used then it should also be removed
+  /// from the [devices] stream. This method takes in a [BluetoothDevice] to
+  /// be removed from this stream.
+  ///
+  @override
+  Future<void> _forgetDevice(final BluetoothDevice device) async {
+    final set = _knownDevicesStream.value ?? <BluetoothDevice>{};
+    if (set.remove(device)) {
+      _knownDevicesStream.add(set);
+    }
   }
 }

--- a/lib/web/web_bluetooth_device.dart
+++ b/lib/web/web_bluetooth_device.dart
@@ -150,6 +150,41 @@ class WebBluetoothDevice {
       _JSUtil.hasProperty(_jsObject, "watchAdvertisements");
 
   ///
+  /// Forget the device. This means that the device will be forgotten by the
+  /// browser and no longer shows up in [Bluetooth.getDevices].
+  ///
+  /// Once forget has been called you won't be able to communicate with the
+  /// device anymore.
+  ///
+  /// May throw:
+  ///
+  /// - [NativeAPINotImplementedError] if the user agent doesn't have the
+  ///   forget method. Use [hasForget] to mitigate this.
+  ///
+  /// **NOTE:** Calling forget on a device retrieved via
+  /// [Bluetooth.requestLEScan] will cause chrome to crash
+  /// (last tested on 2022-12-23).
+  ///
+  /// **NOTE:** Forgetting a device twice will cause chrome to crash
+  /// (last tested on 2022-12-23).
+  ///
+  /// See:
+  ///
+  /// - https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-forget
+  ///
+  Future<void> forget() async {
+    if (!hasForget) {
+      throw NativeAPINotImplementedError("forget");
+    }
+    await _JSUtil.promiseToFuture(_JSUtil.callMethod(_jsObject, "forget", []));
+  }
+
+  ///
+  /// Check to see if the browser/ user agent has the forget method.
+  ///
+  bool get hasForget => _JSUtil.hasProperty(_jsObject, "forget");
+
+  ///
   /// If the device is watching for advertisements.
   /// If advertisements are not unsupported then it will always return `false`.
   ///


### PR DESCRIPTION
- Found a new way to crash chrome by forgetting a device returned from an `advertisementreceived` event.
- Found another way to crash chrome by forgetting a device twice.