### PR TITLE
Add optional flag in requestDevice api to check availability

### DIFF
--- a/lib/src/flutter_web_bluetooth_interface.dart
+++ b/lib/src/flutter_web_bluetooth_interface.dart
@@ -63,6 +63,10 @@ abstract class FlutterWebBluetoothInterface {
   /// If you want multiple devices you will need to call this method multiple
   /// times, the user however can still click the already connected device twice.
   ///
+  /// To bypass this library's adapter availability check, set [checkAvailability]
+  /// to `false` (default is `true`). Errors from an unavailable adapter will then
+  /// come directly from the underlying native `requestDevice` API call.
+  ///
   /// - May throw [NativeAPINotImplementedError] if the native api is not
   /// implemented for this user agent (browser).
   ///
@@ -79,7 +83,10 @@ abstract class FlutterWebBluetoothInterface {
   ///
   /// See: [RequestOptionsBuilder]
   ///
-  Future<BluetoothDevice> requestDevice(final RequestOptionsBuilder options);
+  Future<BluetoothDevice> requestDevice(
+    final RequestOptionsBuilder options, {
+    final bool checkAvailability = true,
+  });
 
   ///
   /// The [advertisements] stream emits an event with a

--- a/lib/src/flutter_web_bluetooth_unsupported.dart
+++ b/lib/src/flutter_web_bluetooth_unsupported.dart
@@ -73,7 +73,10 @@ class FlutterWebBluetooth extends FlutterWebBluetoothInterface {
   Stream<Set<BluetoothDevice>> get devices => Stream.value(<BluetoothDevice>{});
 
   @override
-  Never requestDevice(final RequestOptionsBuilder options) {
+  Never requestDevice(
+    final RequestOptionsBuilder options, {
+    final bool checkAvailability = true,
+  }) {
     throw NativeAPINotImplementedError("requestDevice");
   }
 

--- a/lib/src/flutter_web_bluetooth_web.dart
+++ b/lib/src/flutter_web_bluetooth_web.dart
@@ -161,6 +161,10 @@ class FlutterWebBluetooth extends FlutterWebBluetoothInterface {
   /// If you want multiple devices you will need to call this method multiple
   /// times, the user however can still click the already connected device twice.
   ///
+  /// To bypass this library's adapter availability check, set [checkAvailability]
+  /// to `false` (default is `true`). Errors from an unavailable adapter will then
+  /// come directly from the underlying native `requestDevice` API call.
+  ///
   /// - May throw [NativeAPINotImplementedError] if the native api is not
   /// implemented for this user agent (browser).
   ///
@@ -179,11 +183,13 @@ class FlutterWebBluetooth extends FlutterWebBluetoothInterface {
   ///
   @override
   Future<BluetoothDevice> requestDevice(
-      final RequestOptionsBuilder options) async {
+    final RequestOptionsBuilder options, {
+    final bool checkAvailability = true,
+  }) async {
     if (!isBluetoothApiSupported) {
       throw NativeAPINotImplementedError("requestDevice");
     }
-    if (!(await Bluetooth.getAvailability())) {
+    if (checkAvailability && !(await Bluetooth.getAvailability())) {
       throw BluetoothAdapterNotAvailable("requestDevice");
     }
     final convertedOptions = options.toRequestOptions();


### PR DESCRIPTION
I've added an optional `checkAvailability` flag to the `requestDevice` API.

This change addresses an issue specific to the Brave browser, where even though navigator.bluetooth is present (i.e., isBluetoothSupported returns true), the Web Bluetooth API is still disabled by default via an extra brave specific experimental flag.

Current Behavior on Brave:
- isBluetoothSupported → true (because navigator.bluetooth exists)

- isAvailable() → false (because the experimental flag is disabled)

- If requestDevice() is called without checking isAvailable(), Brave throws the following error:

```
Uncaught NotFoundError: Web Bluetooth API globally disabled.
```

From the app's point of view, this can be confusing since Bluetooth seems "supported" but silently fails unless the internal flag is enabled.

To improve developer experience:

I’ve opened another [PR](https://github.com/jeroen1602/flutter_web_bluetooth/pull/133) to expose the isAvailable() API.

The checkAvailability flag in requestDevice() gives developers control:
They can choose whether to internally check isAvailable() before attempting a request, or handle the error themselves.

Please let me know if you have a better solution in mind.

Do you think we should entirely remove the internal isAvailable() check from requestDevice() ?

<img width="882" alt="Screenshot 2025-05-27 at 1 45 41 PM" src="https://github.com/user-attachments/assets/c7839778-a956-4d19-bd57-657305925473" />
